### PR TITLE
Enforce IPv4 for apt

### DIFF
--- a/cluster-api/preKubeadmCommands.sh
+++ b/cluster-api/preKubeadmCommands.sh
@@ -38,6 +38,12 @@ mkdir -p /etc/kubernetes/pki
 cp ./manifests/audit-policy.yaml /etc/kubernetes/pki/audit-policy.yaml
 cp ./manifests/audit-sink.yaml /etc/kubernetes/pki/audit-sink.yaml
 
+# add host overlay
+(
+  cd ../host
+  cp -v -r . /
+)
+
 # ensure mounts
 sed -ri '/\\sswap\\s/s/^#?/#/' /etc/fstab
 swapoff -a
@@ -123,9 +129,3 @@ net.ipv4.ip_forward                 = 1
 net.bridge.bridge-nf-call-ip6tables = 1
 EOF
 sysctl --system
-
-# add host overlay
-(
-  cd ../host
-  cp -v -r . /
-)

--- a/host/etc/apt/apt.conf.d/1000-force-ipv4-transport
+++ b/host/etc/apt/apt.conf.d/1000-force-ipv4-transport
@@ -1,0 +1,1 @@
+Acquire::ForceIPv4 "true";


### PR DESCRIPTION
Recently some issues have popped up with the init stage of a Pair instance. The `apt install` blocks are using IPv6 addresses and are failing. This addresses the issue by only using IPv4