### PR TITLE
Ensure attach uses Pair instance context

### DIFF
--- a/host/usr/local/bin/attach
+++ b/host/usr/local/bin/attach
@@ -1,2 +1,6 @@
 #!/bin/bash
-kubectl -n "$(kubectl -n default get configmap pair-instance -o=jsonpath="{.data.username}" | tr "[:upper:]" "[:lower:]")" exec -it statefulset/environment -- attach
+
+. <(sudo cat {/var/run/host,}/root/.sharing-io-pair-init.env)
+export KUBE_CONTEXT="kubernetes-admin@${SHARINGIO_PAIR_INSTANCE_NAME}"
+USERNAME="$(kubectl --context "${KUBE_CONTEXT:-}" -n default get configmap pair-instance -o=jsonpath="{.data.username}" | tr "[:upper:]" "[:lower:]")"
+kubectl --context "${KUBE_CONTEXT:-}" -n "${USERNAME:-}" exec -it statefulset/environment -- attach


### PR DESCRIPTION
Sometimes if there are multiple contexts and the default isn't current, `attach` doesn't work.